### PR TITLE
Enforce structured meta in logger with dot-separated event and scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,35 @@ If you configure `level: "warn"`, only `warn()` and `error()` will produce outpu
 
 <br />
 
+## Structured Logging
+You can optionally enrich your logs with a structured meta object.
+
+If you provide either event or scope, you must provide both. This helps ensure logs are meaningful, searchable, and system-aware.
+
+Both `event` and `scope` must be lowercase dot-separated strings, like:
+
+event: `user.signup.success`
+
+scope: `auth.routes.signup`
+
+You can also add any extra fields:
+
+```ts
+logger.info('User signed up', {
+  event: 'user.signup.success',
+  scope: 'auth.routes.signup',
+  user_id: 'u_123',
+  duration_ms: 142,
+  outcome: 'success',
+})
+```
+
+If only one of `event` or `scope` is provided, TypeScript will raise an error.
+
+🔗 See implementation details in [#1](https://github.com/gambonny/cflo/pull/1) – Enforce structured meta in logger
+
+<br />
+
 ## Usage
 
 ```ts

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "tsdown": "^0.11.9",
+    "type-fest": "^4.41.0",
     "typescript": "^5.8.3",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.1.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       tsdown:
         specifier: ^0.11.9
         version: 0.11.9(typescript@5.8.3)
+      type-fest:
+        specifier: ^4.41.0
+        version: 4.41.0
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -740,6 +743,10 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
+
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
@@ -1409,6 +1416,8 @@ snapshots:
 
   tslib@2.8.1:
     optional: true
+
+  type-fest@4.41.0: {}
 
   typescript@5.8.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+onlyBuiltDependencies:
+  - esbuild

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,0 @@
-onlyBuiltDependencies:
-  - esbuild

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1,10 +1,10 @@
-import type { LoggerConfig } from "@/types"
+import type { LoggerConfig, Meta } from "@/types"
 
 export function formatLog(
 	level: LoggerConfig["level"],
 	format: LoggerConfig["format"],
 	msg: string,
-	meta?: unknown,
+	meta?: Meta,
 ): string {
 	if (format === "json") {
 		return JSON.stringify({

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,29 @@
+import type { RequireAllOrNone } from "type-fest"
 import type { LoggerConfigContract } from "@/contracts"
 import type { InferOutput } from "valibot"
 
+// Restrict each segment to lowercase only
+type LowercaseSegment = `${Lowercase<string>}`
+
+// Recursive pattern: at least one dot required
+export type DotSeparated =
+	| `${LowercaseSegment}.${LowercaseSegment}`
+	| `${LowercaseSegment}.${LowercaseSegment}.${LowercaseSegment}`
+	| `${LowercaseSegment}.${LowercaseSegment}.${LowercaseSegment}.${LowercaseSegment}`
+	| `${LowercaseSegment}.${LowercaseSegment}.${LowercaseSegment}.${LowercaseSegment}.${LowercaseSegment}`
+
+type StructuredMeta = {
+	event: DotSeparated
+	scope: DotSeparated
+}
+
+export type Meta = RequireAllOrNone<StructuredMeta> & {
+	[key: string]: unknown
+}
+
 // exports
 export type LoggerConfig = InferOutput<typeof LoggerConfigContract>
-export type LogMethod = (msg: string, meta?: unknown) => void
+export type LogMethod = (msg: string, meta: Meta) => void
 
 export interface Logger {
 	debug: LogMethod

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
-import type { RequireAllOrNone } from "type-fest"
 import type { LoggerConfigContract } from "@/contracts"
+import type { RequireAllOrNone } from "type-fest"
 import type { InferOutput } from "valibot"
 
 // Restrict each segment to lowercase only


### PR DESCRIPTION
## Summary

This PR introduces structured observability metadata for log entries by enforcing the presence of `event` and `scope` fields using TypeScript template literals and `RequireAllOrNone` from `type-fest`.

- Both `event` and `scope` must be dot-separated lowercase strings (e.g., `auth.routes.signup`)
- Developers can omit both, but **cannot provide just one**
- This pattern encourages meaningful, queryable, and hierarchical logs

## Why

To improve developer experience and observability discipline:
- Enforces consistent log structure
- Prevents ambiguous or shallow log messages
- Aligns with structured logging and system-oriented architecture principles

## Technical

- Added `DotSeparated` type using template literals
- Created `Meta` type with `RequireAllOrNone`
- Updated `formatLog` to use `Meta` instead of `unknown`