### PR TITLE
Add optional static context injection to logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,43 +42,22 @@ If you configure `level: "warn"`, only `warn()` and `error()` will produce outpu
 
 <br />
 
-## Structured Logging
-You can optionally enrich your logs with a structured meta object.
-
-If you provide either event or scope, you must provide both. This helps ensure logs are meaningful, searchable, and system-aware.
-
-Both `event` and `scope` must be lowercase dot-separated strings, like:
-
-event: `user.signup.success`
-
-scope: `auth.routes.signup`
-
-You can also add any extra fields:
-
-```ts
-logger.info('User signed up', {
-  event: 'user.signup.success',
-  scope: 'auth.routes.signup',
-  user_id: 'u_123',
-  duration_ms: 142,
-  outcome: 'success',
-})
-```
-
-If only one of `event` or `scope` is provided, TypeScript will raise an error.
-
-🔗 See implementation details in [#1](https://github.com/gambonny/cflo/pull/1) – Enforce structured meta in logger
-
-<br />
 
 ## Usage
 
 ```ts
 import { createLogger } from '@gambonny/cflo'
 
+// `createLogger` takes two arguments:
+// 1. A config object (e.g. log level and format)
+// 2. An optional context object, injected into every log as `meta.context`
+// Useful for attaching request - or environment-level info like `request_id`, `region`, or `deployment_id`
 const logger = createLogger({
   level: 'info',
   format: 'json',
+}, {
+  request_id: 'abc-123',
+  region: 'us-east-1'
 })
 
 logger.info('User registered', { email: 'user@example.com' })
@@ -97,6 +76,38 @@ const logger = createLogger({
 If the config is invalid (e.g. `LOGGER_LEVEL="silent"`), `cflo` will:
 - Emit a warning via `console.warn`
 - Fallback to `level: "debug"` and `format: "pretty"`
+
+<br />
+
+## Structured Logging
+You can optionally enrich your logs with a structured meta object.
+
+If you provide either event or scope, you must provide both. This helps ensure logs are meaningful, searchable, and system-aware.
+
+Both `event` and `scope` must be lowercase dot-separated strings, like:
+```ts
+  event: 'user.signup.success'
+  scope: 'auth.routes.signup'
+```
+
+You can also add any extra fields:
+
+```ts
+logger.info('User signed up', {
+  event: 'user.signup.success',
+  scope: 'auth.routes.signup',
+  user_id: 'u_123',
+  duration_ms: 142,
+  outcome: 'success',
+})
+```
+
+If only one of `event` or `scope` is provided, TypeScript will raise an error.
+
+> ⚠️ Important: `context` is a reserved key that will be automatically injected if passed during `createLogger(...)`.
+> You must not include `context` manually in the `meta` object — TypeScript will raise an error if you try.
+
+🔗 See implementation details in [#1](https://github.com/gambonny/cflo/pull/1) – Enforce structured meta in logger
 
 <br />
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "tsdown",
     "test": "vitest run",
     "lint": "biome check ./src",
+    "lint:fix": "biome check --fix --unsafe ./src",
     "typecheck": "tsc --noEmit"
   },
   "exports": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,17 +2,23 @@ import { validateLoggerConfig } from "@/contracts"
 import { formatLog } from "@/formatter"
 import { getSupportedLevels, shouldLogLevel } from "@/levels"
 import type { Logger, LoggerConfig } from "@/types"
+import type { JsonObject } from "type-fest"
 
 const supportedLevels = getSupportedLevels()
 
-export function createLogger(input: LoggerConfig): Logger {
+export function createLogger(
+	input: LoggerConfig,
+	context?: JsonObject,
+): Logger {
 	const config = validateLoggerConfig(input)
 	const logger: Partial<Logger> = {}
 
 	for (const level of supportedLevels) {
 		logger[level] = (msg, meta) => {
 			if (!shouldLogLevel(level, config.level)) return
-			console[level](formatLog(level, config.format, msg, meta))
+
+			const metaWithContext = context ? { ...meta, context } : meta
+			console[level](formatLog(level, config.format, msg, metaWithContext))
 		}
 	}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,9 @@ export type Meta = RequireAllOrNone<StructuredMeta> & {
 
 // exports
 export type LoggerConfig = InferOutput<typeof LoggerConfigContract>
-export type LogMethod = (msg: string, meta: Meta) => void
+// `context` is reserved for internal use and injected automatically during logger creation.
+// To prevent accidental overrides, it is explicitly forbidden in the public API.
+export type LogMethod = (msg: string, meta: Meta & { context?: never }) => void
 
 export interface Logger {
 	debug: LogMethod

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -62,4 +62,29 @@ describe("cflo logger", () => {
 		expect(warn).toHaveBeenCalledOnce()
 		expect(warn.mock.calls[0][0]).toContain("logger.table is not supported")
 	})
+
+	it("injects context into meta when provided", () => {
+		const jsonOutput: string[] = []
+
+		vi.spyOn(console, "info").mockImplementation(msg => {
+			jsonOutput.push(msg)
+		})
+
+		const logger = createLogger(
+			{ level: "info", format: "json" },
+			{ request_id: "abc-123", region: "co" },
+		)
+
+		logger.info("with context", { user: "john" })
+
+		const raw = jsonOutput.find(s => s.includes("with context"))
+		expect(raw).toBeDefined()
+
+		const parsed = JSON.parse(raw ?? "")
+
+		expect(parsed.meta).toEqual({
+			user: "john",
+			context: { request_id: "abc-123", region: "co" },
+		})
+	})
 })


### PR DESCRIPTION
Adds support for passing a static `context` object to `createLogger()`. If provided, it’s automatically injected into `meta.context` for all log entries.

Useful for attaching request-level or environment metadata like `request_id` or `region`.

Includes test for context injection in JSON logs.