### PR TITLE
Refactor createLogger to use a single options object

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,16 +48,17 @@ If you configure `level: "warn"`, only `warn()` and `error()` will produce outpu
 ```ts
 import { createLogger } from '@gambonny/cflo'
 
-// `createLogger` takes two arguments:
-// 1. A config object (e.g. log level and format)
-// 2. An optional context object, injected into every log as `meta.context`
-// Useful for attaching request - or environment-level info like `request_id`, `region`, or `deployment_id`
+// `createLogger` accepts an options object.
+// - `level` and `format` define the logger's behavior.
+// - `context` is optional and will be injected into every log as `meta.context`.
+// Useful for adding environment-level metadata like `request_id`, `region`, or `deployment_id`.
 const logger = createLogger({
   level: 'info',
   format: 'json',
-}, {
-  request_id: 'abc-123',
-  region: 'us-east-1'
+  context{
+    request_id: 'abc-123',
+    region: 'us-east-1'
+  }
 })
 
 logger.info('User registered')
@@ -75,7 +76,7 @@ const logger = createLogger({
 
 If the config is invalid (e.g. `LOGGER_LEVEL="silent"`), `cflo` will:
 - Emit a warning via `console.warn`
-- Fallback to `level: "debug"` and `format: "pretty"`
+- Fallback to `level: "debug"` and `format: "json"`
 
 <br />
 
@@ -121,3 +122,4 @@ Only the following `console` methods are supported by the Workers runtime:
 - `console.error`
 
 Any unsupported method accessed via the logger (e.g. `logger.table()`) will emit a warning and do nothing.
+

--- a/src/formats.ts
+++ b/src/formats.ts
@@ -1,4 +1,4 @@
-const logFormats = ["pretty", "json"] as const
+const logFormats = ["json", "pretty"] as const
 
 export function getSupportedFormats(): readonly (typeof logFormats)[number][] {
 	return logFormats

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,18 +2,12 @@ import { validateLoggerConfig } from "@/contracts"
 import { formatLog } from "@/formatter"
 import { getSupportedLevels, shouldLogLevel } from "@/levels"
 import type { Logger, LoggerConfig } from "@/types"
-import type { JsonObject } from "type-fest"
 
-const supportedLevels = getSupportedLevels()
-
-export function createLogger(
-	input: LoggerConfig,
-	context?: JsonObject,
-): Logger {
-	const config = validateLoggerConfig(input)
+export function createLogger({ level, format, context }: LoggerConfig): Logger {
+	const config = validateLoggerConfig({ level, format })
 	const logger: Partial<Logger> = {}
 
-	for (const level of supportedLevels) {
+	for (const level of getSupportedLevels()) {
 		logger[level] = (msg, meta) => {
 			if (!shouldLogLevel(level, config.level)) return
 
@@ -26,7 +20,7 @@ export function createLogger(
 		get(target, prop) {
 			if (prop in target) return target[prop as keyof Logger]
 			console.warn(
-				`logger.${String(prop)} is not supported in this environment. Supported: ${supportedLevels.join(", ")}`,
+				`logger.${String(prop)} is not supported in this environment. Supported: ${getSupportedLevels().join(", ")}`,
 			)
 			return () => {}
 		},

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -70,10 +70,11 @@ describe("cflo logger", () => {
 			jsonOutput.push(msg)
 		})
 
-		const logger = createLogger(
-			{ level: "info", format: "json" },
-			{ request_id: "abc-123", region: "co" },
-		)
+		const logger = createLogger({
+			level: "info",
+			format: "json",
+			context: { request_id: "abc-123", region: "co" },
+		})
 
 		logger.info("with context", { user: "john" })
 


### PR DESCRIPTION
## Summary

Refactors `createLogger` to accept a single configuration object instead of two separate arguments.

### ✨ Changes

- `createLogger({ level, format, context })` replaces `createLogger(config, context)`
- Improves readability and matches common DX patterns (e.g. Vite, TanStack)
- Extracts `levelFallback` and `formatFallback` for clarity
- Preserves `context` even if config is partially invalid
- Adds structured, readable return paths for full, partial, and fallback cases