### PR TITLE
feat(hono): add useLogger() middleware for route-scoped logger injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "license": "MIT",
   "packageManager": "pnpm@10.10.0",
   "devDependencies": {
+    "hono": "^4.7.10",
     "@biomejs/biome": "^1.9.4",
     "tsdown": "^0.11.9",
     "type-fest": "^4.41.0",
@@ -41,5 +42,13 @@
   },
   "files": [
     "dist"
-  ]
+  ],
+  "peerDependencies": {
+    "hono": "^4.7.10"
+  },
+  "peerDependenciesMeta": {
+    "hono": {
+      "optional": true
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
       '@biomejs/biome':
         specifier: ^1.9.4
         version: 1.9.4
+      hono:
+        specifier: ^4.7.10
+        version: 4.7.10
       tsdown:
         specifier: ^0.11.9
         version: 0.11.9(typescript@5.8.3)
@@ -586,6 +589,10 @@ packages:
 
   globrex@0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
+
+  hono@4.7.10:
+    resolution: {integrity: sha512-QkACju9MiN59CKSY5JsGZCYmPZkA6sIW6OFCUp7qDjZu6S6KHtJHhAc9Uy9mV9F8PJ1/HQ3ybZF2yjCa/73fvQ==}
+    engines: {node: '>=16.9.0'}
 
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
@@ -1262,6 +1269,8 @@ snapshots:
       resolve-pkg-maps: 1.0.0
 
   globrex@0.1.2: {}
+
+  hono@4.7.10: {}
 
   hookable@5.5.3: {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,4 +27,5 @@ export function createLogger({ level, format, context }: LoggerConfig): Logger {
 	})
 }
 
+export { useLogger } from "@/integrations/hono/useLogger"
 export type { Logger, LoggerConfig } from "@/types"

--- a/src/integrations/hono/useLogger.ts
+++ b/src/integrations/hono/useLogger.ts
@@ -1,0 +1,29 @@
+import type { MiddlewareHandler } from "hono"
+import type { Logger, LoggerConfig, Meta } from "@/types"
+import { createLogger } from "@/index"
+import type { DotSeparated } from "@/types"
+
+export function useLogger(config: LoggerConfig): MiddlewareHandler {
+	const logger = createLogger(config)
+
+	return async (c, next) => {
+		// Inject getLogger(route) into c.var
+		c.set("getLogger", (route: DotSeparated): Logger => {
+			const scopedLogger: Partial<Logger> = {}
+
+			for (const level of Object.keys(logger) as Array<keyof Logger>) {
+				scopedLogger[level] = (msg: string, meta?: Meta) => {
+					const mergedMeta: Meta = {
+						...meta,
+						route: meta?.route ?? route,
+					}
+					logger[level](msg, mergedMeta)
+				}
+			}
+
+			return scopedLogger as Logger
+		})
+
+		await next()
+	}
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,3 +34,7 @@ export interface Logger {
 	warn: LogMethod
 	error: LogMethod
 }
+
+export interface LoggerContext {
+	getLogger: (route: DotSeparated) => Logger
+}

--- a/tests/useLogger.test.ts
+++ b/tests/useLogger.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { Hono } from "hono"
+import { useLogger } from "../src/integrations/hono/useLogger"
+import type { LoggerConfig, LoggerContext } from "../src/types"
+import { getSupportedLevels } from "../src/levels"
+
+describe("useLogger middleware", () => {
+	const outputs: string[] = []
+
+	beforeEach(() => {
+		outputs.length = 0
+		for (const level of getSupportedLevels()) {
+			vi.spyOn(console, level).mockImplementation(msg => {
+				outputs.push(msg)
+			})
+		}
+	})
+
+	it("injects getLogger into context and logs with correct route", async () => {
+		const app = new Hono<{ Variables: LoggerContext }>()
+
+		const config: LoggerConfig = {
+			level: "info",
+			format: "json",
+		}
+
+		app.use(useLogger(config))
+
+		app.get("/signup", c => {
+			const logger = c.var.getLogger("auth.routes.signup")
+			logger.info("User signed up", {
+				event: "user.signup.success",
+				scope: "db.write",
+				user_id: "u_456",
+			})
+			return c.text("ok")
+		})
+
+		const res = await app.request("/signup")
+		expect(res.status).toBe(200)
+
+		const log = outputs.find(line => line.includes("User signed up"))
+		if (!log)
+			throw new Error("Expected log containing 'User signed up' not found")
+
+		const json = JSON.parse(log)
+		expect(json.level).toBe("info")
+		expect(json.meta.route).toBe("auth.routes.signup")
+		expect(json.meta.event).toBe("user.signup.success")
+		expect(json.meta.scope).toBe("db.write")
+		expect(json.meta.user_id).toBe("u_456")
+	})
+})


### PR DESCRIPTION
This PR introduces a new Hono integration middleware `useLogger()` to simplify logger setup across routes using `cflo`.

- Injects `getLogger(route)` into `c.var`, scoped to each request
- Automatically enriches `meta.route` for all log calls
- Does not override core logger behavior (`info`, `debug`, etc.)
- Fully typed via `DotSeparated`
- Optimized for ergonomics and consistency with Hono middleware conventions

Includes tests for:
- Logger injection
- Route-specific scope behavior
- Structured JSON logging output

No breaking changes. All existing logger logic remains untouched.

